### PR TITLE
Update example for generic target specs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OBJCOPY=arm-none-eabi-objcopy
 OBJDUMP=arm-none-eabi-objdump
 
 # Target
-TARGET=lpc17xx
+TARGET=thumbv7m-none-eabi
 
 # Files
 OUT_DIR=target/$(TARGET)/release

--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ Building the Example
 The code can be built with cargo.
 
 ```
-$ cargo build --release --target=lpc17xx
+$ cargo build --release --target=thumbv7m-none-eabi
 ```
 
 This will generate an object file, to turn this into a bin file or hex
 file you will need to run objdump on the resultant binary.  E.g.
 
 ```
-$ objdump -O binary ./target/lpc17xx/release/blink blink.bin
+$ objdump -O binary ./target/thumbv7m-none-eabi/release/blink blink.bin
 ```
 
 Since you are like to need to type this quite frequently, you may want

--- a/thumbv7m-none-eabi.json
+++ b/thumbv7m-none-eabi.json
@@ -11,7 +11,6 @@
     "target-endian": "little",
     "target-pointer-width": "32",
     "no-compiler-rt": true,
-    "linker": "arm-none-eabi-gcc",
     "pre-link-args": [
         "-lm", "-lgcc", "-mcpu=cortex-m3", "-mthumb",
         "-Tlayout.ld"


### PR DESCRIPTION
Generic target specs are now in upstream. Updated the example.
